### PR TITLE
perf: fold constant byte operations in std/math/uints

### DIFF
--- a/std/math/uints/bytes.go
+++ b/std/math/uints/bytes.go
@@ -166,14 +166,43 @@ func (bf *Bytes) twoArgFn(tbl *logderivprecomp.Precomputed, a ...U8) U8 {
 	if len(a) == 1 {
 		return a[0]
 	}
-	ret := tbl.Query(a[0].Val, a[1].Val)[0]
+	ret := bf.queryOrFold(tbl, a[0].Val, a[1].Val)
 	for i := 2; i < len(a); i++ {
-		ret = tbl.Query(ret, a[i].Val)[0]
+		ret = bf.queryOrFold(tbl, ret, a[i].Val)
 	}
-	// because the response comes from the lookup table, then (assuming that the
-	// function which built the table is correct) we can assume that the value
-	// is in range. Thus we set the internal flag to true.
+	// because the response comes from the lookup table (or from constant
+	// folding of width-checked operands), then (assuming that the function
+	// which built the table is correct) we can assume that the value is in
+	// range. Thus we set the internal flag to true.
 	return bf.packInternal(ret)
+}
+
+// queryOrFold evaluates the byte operation implemented by tbl natively when
+// both operands are compile-time constants, avoiding the lookup query and its
+// constraints. The operands are already width-checked ([Bytes.enforceWidth]
+// for the inputs, previous lookups or folds for the intermediates), but we
+// still guard on the width so that an out-of-range constant falls back to the
+// lookup path instead of being truncated silently.
+func (bf *Bytes) queryOrFold(tbl *logderivprecomp.Precomputed, x, y frontend.Variable) frontend.Variable {
+	cx, xIsConst := bf.api.ConstantValue(x)
+	if !xIsConst || cx.BitLen() > 8 {
+		return tbl.Query(x, y)[0]
+	}
+	cy, yIsConst := bf.api.ConstantValue(y)
+	if !yIsConst || cy.BitLen() > 8 {
+		return tbl.Query(x, y)[0]
+	}
+	xb, yb := uint8(cx.Uint64()), uint8(cy.Uint64())
+	switch tbl {
+	case bf.xorT:
+		return xb ^ yb
+	case bf.andT:
+		return xb & yb
+	case bf.orT:
+		return xb | yb
+	default:
+		return tbl.Query(x, y)[0]
+	}
 }
 
 func (bf *Bytes) Not(a U8) U8 {

--- a/std/math/uints/bytes_test.go
+++ b/std/math/uints/bytes_test.go
@@ -1,0 +1,101 @@
+package uints
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/test"
+)
+
+// constFoldMixedCircuit chains compile-time constants with a witness operand
+// so that both the folded and the lookup paths are exercised in one query
+// chain: the leading constant pair folds, the witness operand forces a lookup
+// and the trailing constant queries against a non-constant intermediate.
+type constFoldMixedCircuit struct {
+	In       U8
+	Expected U8
+	mode     int
+}
+
+func (c *constFoldMixedCircuit) Define(api frontend.API) error {
+	uapi, err := NewBytes(api)
+	if err != nil {
+		return fmt.Errorf("NewBytes: %w", err)
+	}
+	var res U8
+	switch c.mode {
+	case 0:
+		res = uapi.And(NewU8(0x3c), NewU8(0x5a), c.In, NewU8(0xf0))
+	case 1:
+		res = uapi.Or(NewU8(0x3c), NewU8(0x5a), c.In, NewU8(0xf0))
+	case 2:
+		res = uapi.Xor(NewU8(0x3c), NewU8(0x5a), c.In, NewU8(0xf0))
+	}
+	uapi.AssertIsEqual(res, c.Expected)
+	return nil
+}
+
+func TestByteOpConstantFoldMixed(t *testing.T) {
+	assert := test.NewAssert(t)
+	in := uint8(0xa7)
+	assert.Run(func(assert *test.Assert) {
+		expected := 0x3c & 0x5a & in & 0xf0
+		assert.CheckCircuit(&constFoldMixedCircuit{mode: 0}, test.WithValidAssignment(&constFoldMixedCircuit{In: NewU8(in), Expected: NewU8(expected)}))
+		assert.CheckCircuit(&constFoldMixedCircuit{mode: 0}, test.WithInvalidAssignment(&constFoldMixedCircuit{In: NewU8(in), Expected: NewU8(expected ^ 1)}))
+	}, "and")
+	assert.Run(func(assert *test.Assert) {
+		expected := 0x3c | 0x5a | in | 0xf0
+		assert.CheckCircuit(&constFoldMixedCircuit{mode: 1}, test.WithValidAssignment(&constFoldMixedCircuit{In: NewU8(in), Expected: NewU8(expected)}))
+		assert.CheckCircuit(&constFoldMixedCircuit{mode: 1}, test.WithInvalidAssignment(&constFoldMixedCircuit{In: NewU8(in), Expected: NewU8(expected ^ 1)}))
+	}, "or")
+	assert.Run(func(assert *test.Assert) {
+		expected := 0x3c ^ 0x5a ^ in ^ 0xf0
+		assert.CheckCircuit(&constFoldMixedCircuit{mode: 2}, test.WithValidAssignment(&constFoldMixedCircuit{In: NewU8(in), Expected: NewU8(expected)}))
+		assert.CheckCircuit(&constFoldMixedCircuit{mode: 2}, test.WithInvalidAssignment(&constFoldMixedCircuit{In: NewU8(in), Expected: NewU8(expected ^ 1)}))
+	}, "xor")
+}
+
+// constFoldOnlyCircuit performs byte operations exclusively on compile-time
+// constants; with folding it must not emit any lookup query.
+type constFoldOnlyCircuit struct {
+	Dummy frontend.Variable
+}
+
+func (c *constFoldOnlyCircuit) Define(api frontend.API) error {
+	uapi, err := NewBytes(api)
+	if err != nil {
+		return fmt.Errorf("NewBytes: %w", err)
+	}
+	and := uapi.And(NewU8(0x3c), NewU8(0x5a), NewU8(0xf0))
+	or := uapi.Or(NewU8(0x3c), NewU8(0x5a), NewU8(0x0f))
+	xor := uapi.Xor(NewU8(0x3c), NewU8(0x5a), NewU8(0xff))
+	uapi.AssertIsEqual(and, NewU8(0x3c&0x5a&0xf0))
+	uapi.AssertIsEqual(or, NewU8(0x3c|0x5a|0x0f))
+	uapi.AssertIsEqual(xor, NewU8(0x3c^0x5a^0xff))
+	return nil
+}
+
+// byteOpBaselineCircuit instantiates the same tables but performs no byte
+// operations. Constant-only operations must not add constraints on top of it.
+type byteOpBaselineCircuit struct {
+	Dummy frontend.Variable
+}
+
+func (c *byteOpBaselineCircuit) Define(api frontend.API) error {
+	if _, err := NewBytes(api); err != nil {
+		return fmt.Errorf("NewBytes: %w", err)
+	}
+	return nil
+}
+
+func TestByteOpConstantFoldAddsNoConstraints(t *testing.T) {
+	assert := test.NewAssert(t)
+	folded, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &constFoldOnlyCircuit{})
+	assert.NoError(err)
+	baseline, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &byteOpBaselineCircuit{})
+	assert.NoError(err)
+	assert.Equal(baseline.GetNbConstraints(), folded.GetNbConstraints(), "constant-only byte operations added constraints")
+}


### PR DESCRIPTION
# Description

When both operands of a `Bytes.And`/`Or`/`Xor` byte operation are compile-time constants, evaluate the operation natively at compile time instead of emitting a lookup query. The fold is applied per query in the variadic chain, so constant prefixes and constant–constant pairs fold while any witness operand keeps the exact existing lookup path; `BinaryField` (U32/U64) operations benefit through the shared `twoArgFn`.

Soundness: both operands of a folded query are already width-checked — circuit inputs by `enforceWidth` (which panics on constants wider than 8 bits), intermediates because they come either from a lookup response or from a previous fold that produced a `uint8`. The fold additionally guards on `BitLen() > 8` and falls back to the lookup for anything wider, so a constant can never be silently truncated. An unrecognized table also falls back to the lookup path.

Motivation: byte-oriented circuits routinely mix constants (padding bytes, IVs, domain separators, masks) with witness bytes, and each such constant pair currently costs a lookup query plus its share of the log-derivative table commitment. In a production circuit of ours dominated by SHA-512/HMAC this fold removed ~38,000 R1CS constraints; on gnark's own `std/hash/sha2` gadget see the numbers below.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] New `TestByteOpConstantFoldMixed`: for each of And/Or/Xor, a chain mixing a folded constant pair, a witness operand, and a trailing constant queried against a non-constant intermediate; valid and invalid assignments via `assert.CheckCircuit` (Groth16 + PLONK, bn254 + bls12-381).
- [x] New `TestByteOpConstantFoldAddsNoConstraints`: compiles a constant-only And/Or/Xor circuit and asserts its R1CS constraint count equals a baseline circuit that only instantiates the tables.
- [x] Full existing suites pass: `go test ./std/math/uints/ ./std/hash/sha2/... ./std/hash/sha3/...`

# How has this been benchmarked?

- [x] Compiling the `std/hash/sha2` gadget over a 64-byte message on bn254 (Linux x86-64): R1CS 184,199 → 183,992 constraints; SCS 560,641 → 559,628 constraints.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core bitwise byte logic in circuits; behavior is guarded by width checks and lookup fallback, with new tests, but incorrect folding would affect proof soundness for hash/crypto gadgets.
> 
> **Overview**
> **`Bytes.And` / `Or` / `Xor`** now route each pairwise step through **`queryOrFold`**: when both operands are compile-time constants within 8 bits, the op is evaluated natively instead of emitting a log-derivative lookup. Variadic chains still use lookups wherever a witness or wide constant appears; unknown tables fall back to **`tbl.Query`**.
> 
> **`BinaryField` (U32/U64)** picks this up automatically via the shared **`twoArgFn`**.
> 
> New tests cover mixed constant/witness chains (valid and invalid circuits) and assert constant-only byte ops add **no** R1CS constraints beyond instantiating the lookup tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926e18bb4c0f2d8dd2fd331cbb35d24542412b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->