### PR TITLE
perf: optimize keccack permutation

### DIFF
--- a/std/math/uints/bytes.go
+++ b/std/math/uints/bytes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/std/internal/logderivprecomp"
+	stdbits "github.com/consensys/gnark/std/math/bits"
 	"github.com/consensys/gnark/std/rangecheck"
 )
 
@@ -101,6 +102,22 @@ func NewBytes(api frontend.API) (*Bytes, error) {
 
 func (bf *Bytes) packInternal(val frontend.Variable) U8 {
 	return U8{Val: val, internal: true}
+}
+
+// ToBits decomposes a byte into little-endian bits and constrains the byte to
+// equal the recomposition of these bits.
+func (bf *Bytes) ToBits(a U8) []frontend.Variable {
+	return bf.api.ToBinary(a.Val, 8)
+}
+
+// FromBits packs eight little-endian bits into a byte. The input bits are
+// constrained to be boolean unless they are already marked as boolean by the
+// compiler.
+func (bf *Bytes) FromBits(bits ...frontend.Variable) U8 {
+	if len(bits) != 8 {
+		panic("expected exactly 8 bits")
+	}
+	return bf.packInternal(stdbits.FromBinary(bf.api, bits))
 }
 
 // ValueOf returns a constrainted [U8] variable. For a constant value, use

--- a/std/math/uints/uint8.go
+++ b/std/math/uints/uint8.go
@@ -138,6 +138,11 @@ func (bf *BinaryField[T]) zero() T {
 	return res
 }
 
+// API returns the underlying frontend API.
+func (bf *BinaryField[T]) API() frontend.API {
+	return bf.Bytes.api
+}
+
 // ByteValueOf converts a frontend.Variable into a single byte. If the input
 // doesn't fit into a byte then solver fails.
 func (bf *BinaryField[T]) ByteValueOf(a frontend.Variable) U8 {
@@ -192,6 +197,29 @@ func (bf *BinaryField[T]) PackLSB(a ...U8) T {
 	var ret T
 	for i := range a {
 		ret[i] = a[i]
+	}
+	return ret
+}
+
+// ToBits decomposes a long integer into little-endian bits and constrains each
+// byte to equal the recomposition of its bits.
+func (bf *BinaryField[T]) ToBits(a T) []frontend.Variable {
+	ret := make([]frontend.Variable, 0, bf.lenBts()*8)
+	for i := 0; i < bf.lenBts(); i++ {
+		ret = append(ret, bf.Bytes.ToBits(a[i])...)
+	}
+	return ret
+}
+
+// FromBits packs little-endian bits into a long integer. The number of bits
+// must match the width of T.
+func (bf *BinaryField[T]) FromBits(bits ...frontend.Variable) T {
+	if len(bits) != bf.lenBts()*8 {
+		panic("incorrect number of bits")
+	}
+	var ret T
+	for i := 0; i < bf.lenBts(); i++ {
+		ret[i] = bf.Bytes.FromBits(bits[8*i : 8*(i+1)]...)
 	}
 	return ret
 }

--- a/std/math/uints/uint8_test.go
+++ b/std/math/uints/uint8_test.go
@@ -86,6 +86,26 @@ func TestValueOf(t *testing.T) {
 	assert.CheckCircuit(&valueOfCircuit[U32]{}, test.WithInvalidAssignment(&valueOfCircuit[U32]{In: 0x1234567812345678, Expected: [4]U8{NewU8(0x78), NewU8(0x56), NewU8(0x34), NewU8(0x12)}}))
 }
 
+type bitsRoundTripCircuit struct {
+	In, Expected U64
+}
+
+func (c *bitsRoundTripCircuit) Define(api frontend.API) error {
+	uapi, err := New[U64](api)
+	if err != nil {
+		return err
+	}
+	bits := uapi.ToBits(c.In)
+	res := uapi.FromBits(bits...)
+	uapi.AssertEq(res, c.Expected)
+	return nil
+}
+
+func TestBitsRoundTrip(t *testing.T) {
+	assert := test.NewAssert(t)
+	assert.CheckCircuit(&bitsRoundTripCircuit{}, test.WithValidAssignment(&bitsRoundTripCircuit{In: NewU64(0x0123456789abcdef), Expected: NewU64(0x0123456789abcdef)}))
+}
+
 type addCircuit struct {
 	In       []U32
 	Expected U32

--- a/std/permutation/keccakf/keccak_test.go
+++ b/std/permutation/keccakf/keccak_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/std/permutation/keccakf"
 	"github.com/consensys/gnark/test"
 )
@@ -33,6 +35,33 @@ func (c *keccakfCircuit) Define(api frontend.API) error {
 		uapi.AssertEq(res[i], c.Expected[i])
 	}
 	return nil
+}
+
+type keccakfCountCircuit struct {
+	In       [25]uints.U64
+	Expected [25]uints.U64 `gnark:",public"`
+}
+
+func (c *keccakfCountCircuit) Define(api frontend.API) error {
+	uapi, err := uints.New[uints.U64](api)
+	if err != nil {
+		return err
+	}
+	res := keccakf.Permute(uapi, c.In)
+	for i := range res {
+		uapi.AssertEq(res[i], c.Expected[i])
+	}
+	return nil
+}
+
+func TestKeccakfCount(t *testing.T) {
+	assert := test.NewAssert(t)
+	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &keccakfCountCircuit{})
+	assert.NoError(err)
+	t.Log("KeccakF-1600 r1cs constraints =", ccs.GetNbConstraints(), "instructions =", ccs.GetNbInstructions())
+	ccs, err = frontend.Compile(ecc.BN254.ScalarField(), scs.NewBuilder, &keccakfCountCircuit{})
+	assert.NoError(err)
+	t.Log("KeccakF-1600 scs constraints =", ccs.GetNbConstraints(), "instructions =", ccs.GetNbInstructions())
 }
 
 func TestKeccakf(t *testing.T) {

--- a/std/permutation/keccakf/keccakf.go
+++ b/std/permutation/keccakf/keccakf.go
@@ -6,39 +6,50 @@
 // package.
 //
 // The cost for a single application of permutation is:
-//   - 193650 constraints in Groth16
-//   - 292032 constraints in Plonk
+//   - 94160 constraints in Groth16
+//   - 158486 constraints in Plonk
 package keccakf
 
 import (
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/constraint/solver"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/internal/kvstore"
 	"github.com/consensys/gnark/std/math/uints"
 )
 
-var rc = [24]uints.U64{
-	uints.NewU64(0x0000000000000001),
-	uints.NewU64(0x0000000000008082),
-	uints.NewU64(0x800000000000808A),
-	uints.NewU64(0x8000000080008000),
-	uints.NewU64(0x000000000000808B),
-	uints.NewU64(0x0000000080000001),
-	uints.NewU64(0x8000000080008081),
-	uints.NewU64(0x8000000000008009),
-	uints.NewU64(0x000000000000008A),
-	uints.NewU64(0x0000000000000088),
-	uints.NewU64(0x0000000080008009),
-	uints.NewU64(0x000000008000000A),
-	uints.NewU64(0x000000008000808B),
-	uints.NewU64(0x800000000000008B),
-	uints.NewU64(0x8000000000008089),
-	uints.NewU64(0x8000000000008003),
-	uints.NewU64(0x8000000000008002),
-	uints.NewU64(0x8000000000000080),
-	uints.NewU64(0x000000000000800A),
-	uints.NewU64(0x800000008000000A),
-	uints.NewU64(0x8000000080008081),
-	uints.NewU64(0x8000000000008080),
-	uints.NewU64(0x0000000080000001),
-	uints.NewU64(0x8000000080008008),
+func init() {
+	solver.RegisterHint(xor3Hint, chiHint)
+}
+
+var rc = [24]uint64{
+	0x0000000000000001,
+	0x0000000000008082,
+	0x800000000000808A,
+	0x8000000080008000,
+	0x000000000000808B,
+	0x0000000080000001,
+	0x8000000080008081,
+	0x8000000000008009,
+	0x000000000000008A,
+	0x0000000000000088,
+	0x0000000080008009,
+	0x000000008000000A,
+	0x000000008000808B,
+	0x800000000000008B,
+	0x8000000000008089,
+	0x8000000000008003,
+	0x8000000000008002,
+	0x8000000000000080,
+	0x000000000000800A,
+	0x800000008000000A,
+	0x8000000080008081,
+	0x8000000000008080,
+	0x0000000080000001,
+	0x8000000080008008,
 }
 var rotc = [24]int{
 	1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14,
@@ -52,32 +63,60 @@ var piln = [24]int{
 // Permute applies Keccak-F permutation on the input and returns the permuted vector.
 // Original input is not modified.
 func Permute(uapi *uints.BinaryField[uints.U64], input [25]uints.U64) [25]uints.U64 {
-	var state [25]uints.U64
-	copy(state[:], input[:])
-	return permute(uapi, state)
+	var state [25][64]frontend.Variable
+	for i := range input {
+		bits := uapi.ToBits(input[i])
+		copy(state[i][:], bits)
+	}
+	state = permuteBits(uapi.API(), state)
+
+	var ret [25]uints.U64
+	for i := range ret {
+		ret[i] = uapi.FromBits(state[i][:]...)
+	}
+	return ret
 }
 
-func permute(uapi *uints.BinaryField[uints.U64], st [25]uints.U64) [25]uints.U64 {
-	var t uints.U64
-	var bc [5]uints.U64
+func permuteBits(api frontend.API, st [25][64]frontend.Variable) [25][64]frontend.Variable {
+	if isR1CS(api) {
+		return permuteBitsR1CS(api, st)
+	}
+	return permuteBitsGeneric(api, st)
+}
+
+func isR1CS(api frontend.API) bool {
+	if api.Compiler().Field().Cmp(big.NewInt(3)) <= 0 {
+		return false
+	}
+	_, ok := api.Compiler().ToCanonicalVariable(0).(constraint.LinearExpression)
+	return ok
+}
+
+func permuteBitsGeneric(api frontend.API, st [25][64]frontend.Variable) [25][64]frontend.Variable {
+	var bc [5][64]frontend.Variable
 	for r := 0; r < 24; r++ {
 		// theta
 		for i := 0; i < 5; i++ {
-			bc[i] = uapi.Xor(st[i], st[i+5], st[i+10], st[i+15], st[i+20])
+			for z := 0; z < 64; z++ {
+				bc[i][z] = xor(api, st[i][z], st[i+5][z], st[i+10][z], st[i+15][z], st[i+20][z])
+			}
 		}
 		for i := 0; i < 5; i++ {
-			t = uapi.Xor(bc[(i+4)%5], uapi.Lrot(bc[(i+1)%5], 1))
-			for j := 0; j < 25; j += 5 {
-				st[j+i] = uapi.Xor(st[j+i], t)
+			rot := lrot(bc[(i+1)%5], 1)
+			for z := 0; z < 64; z++ {
+				d := api.Xor(bc[(i+4)%5][z], rot[z])
+				for j := 0; j < 25; j += 5 {
+					st[j+i][z] = api.Xor(st[j+i][z], d)
+				}
 			}
 		}
 		// rho pi
-		t = st[1]
+		t := st[1]
 		for i := 0; i < 24; i++ {
 			j := piln[i]
-			bc[0] = st[j]
-			st[j] = uapi.Lrot(t, rotc[i])
-			t = bc[0]
+			bc0 := st[j]
+			st[j] = lrot(t, rotc[i])
+			t = bc0
 		}
 
 		// chi
@@ -86,11 +125,183 @@ func permute(uapi *uints.BinaryField[uints.U64], st [25]uints.U64) [25]uints.U64
 				bc[i] = st[j+i]
 			}
 			for i := 0; i < 5; i++ {
-				st[j+i] = uapi.Xor(st[j+i], uapi.And(uapi.Not(bc[(i+1)%5]), bc[(i+2)%5]))
+				for z := 0; z < 64; z++ {
+					st[j+i][z] = api.Xor(st[j+i][z], andNot(api, bc[(i+1)%5][z], bc[(i+2)%5][z]))
+				}
 			}
 		}
 		// iota
-		st[0] = uapi.Xor(st[0], rc[r])
+		for z := 0; z < 64; z++ {
+			if (rc[r]>>z)&1 == 1 {
+				st[0][z] = api.Xor(st[0][z], 1)
+			}
+		}
 	}
 	return st
+}
+
+func permuteBitsR1CS(api frontend.API, st [25][64]frontend.Variable) [25][64]frontend.Variable {
+	var bc [5][64]frontend.Variable
+	for r := 0; r < 24; r++ {
+		// theta: C[x] is a five-bit parity using two one-row XOR3s. D[x] is
+		// folded into A[x,y] as XOR3(A[x,y], C[x-1], ROT(C[x+1], 1)).
+		for i := 0; i < 5; i++ {
+			for z := 0; z < 64; z++ {
+				t := xor3R1CS(api, st[i][z], st[i+5][z], st[i+10][z])
+				bc[i][z] = xor3R1CS(api, t, st[i+15][z], st[i+20][z])
+			}
+		}
+		for i := 0; i < 5; i++ {
+			rot := lrot(bc[(i+1)%5], 1)
+			for z := 0; z < 64; z++ {
+				for j := 0; j < 25; j += 5 {
+					st[j+i][z] = xor3R1CS(api, st[j+i][z], bc[(i+4)%5][z], rot[z])
+				}
+			}
+		}
+
+		// rho pi
+		t := st[1]
+		for i := 0; i < 24; i++ {
+			j := piln[i]
+			bc0 := st[j]
+			st[j] = lrot(t, rotc[i])
+			t = bc0
+		}
+
+		// chi
+		for j := 0; j < 25; j += 5 {
+			for i := 0; i < 5; i++ {
+				bc[i] = st[j+i]
+			}
+			for i := 0; i < 5; i++ {
+				for z := 0; z < 64; z++ {
+					st[j+i][z] = chiR1CS(api, bc[i][z], bc[(i+1)%5][z], bc[(i+2)%5][z])
+				}
+			}
+		}
+
+		// iota
+		for z := 0; z < 64; z++ {
+			if (rc[r]>>z)&1 == 1 {
+				st[0][z] = api.Sub(1, st[0][z])
+				api.Compiler().MarkBoolean(st[0][z])
+			}
+		}
+	}
+	return st
+}
+
+func xor(api frontend.API, xs ...frontend.Variable) frontend.Variable {
+	ret := xs[0]
+	for _, x := range xs[1:] {
+		ret = api.Xor(ret, x)
+	}
+	return ret
+}
+
+func andNot(api frontend.API, b, c frontend.Variable) frontend.Variable {
+	plonkAPI, ok := api.Compiler().(frontend.PlonkAPI)
+	if !ok {
+		return api.And(api.Xor(b, 1), c)
+	}
+	// z = (NOT b) AND c = c - bc, with b and c already boolean.
+	z := plonkAPI.EvaluatePlonkExpression(b, c, 0, 1, -1, 0)
+	api.Compiler().MarkBoolean(z)
+	return z
+}
+
+func lrot(a [64]frontend.Variable, c int) [64]frontend.Variable {
+	var ret [64]frontend.Variable
+	for i := range a {
+		ret[(i+c)%64] = a[i]
+	}
+	return ret
+}
+
+type r1cBlueprintKey struct{}
+
+func r1cBlueprintID(api frontend.API) constraint.BlueprintID {
+	kv, ok := api.Compiler().(kvstore.Store)
+	if !ok {
+		panic("compiler does not implement kvstore.Store")
+	}
+	if id := kv.GetKeyValue(r1cBlueprintKey{}); id != nil {
+		return id.(constraint.BlueprintID)
+	}
+	id := api.Compiler().AddBlueprint(&constraint.BlueprintGenericR1C{})
+	kv.SetKeyValue(r1cBlueprintKey{}, id)
+	return id
+}
+
+func addR1C(api frontend.API, left, right, output frontend.Variable) {
+	l, ok := api.Compiler().ToCanonicalVariable(left).(constraint.LinearExpression)
+	if !ok {
+		panic("expected R1CS linear expression")
+	}
+	r, ok := api.Compiler().ToCanonicalVariable(right).(constraint.LinearExpression)
+	if !ok {
+		panic("expected R1CS linear expression")
+	}
+	o, ok := api.Compiler().ToCanonicalVariable(output).(constraint.LinearExpression)
+	if !ok {
+		panic("expected R1CS linear expression")
+	}
+
+	r1c := constraint.R1C{L: l, R: r, O: o}
+	var blueprint constraint.BlueprintGenericR1C
+	calldata := make([]uint32, 0)
+	blueprint.CompressR1C(&r1c, &calldata)
+	api.Compiler().AddInstruction(r1cBlueprintID(api), calldata)
+}
+
+func xor3R1CS(api frontend.API, a, b, c frontend.Variable) frontend.Variable {
+	out, err := api.Compiler().NewHint(xor3Hint, 1, a, b, c)
+	if err != nil {
+		panic(err)
+	}
+	z := out[0]
+	// For boolean a,b,c and char > 3, the multiplier is never zero and this
+	// row uniquely pins z = a XOR b XOR c.
+	left := api.Add(z, api.Mul(2, a), api.Mul(2, b), api.Mul(7, c))
+	right := api.Add(a, b, api.Mul(-4, c), 1)
+	output := api.Add(api.Mul(6, a), api.Mul(6, b), api.Mul(-24, c))
+	addR1C(api, left, right, output)
+	api.Compiler().MarkBoolean(z)
+	return z
+}
+
+func chiR1CS(api frontend.API, a, b, c frontend.Variable) frontend.Variable {
+	out, err := api.Compiler().NewHint(chiHint, 1, a, b, c)
+	if err != nil {
+		panic(err)
+	}
+	z := out[0]
+	// For boolean a,b,c and char > 3, the multiplier is never zero and this
+	// row uniquely pins z = a XOR ((NOT b) AND c).
+	left := api.Add(z, api.Mul(3, a), api.Neg(b), api.Neg(c))
+	right := api.Add(api.Mul(4, a), b, c, -3)
+	output := api.Add(api.Mul(4, a), api.Mul(2, b))
+	addR1C(api, left, right, output)
+	api.Compiler().MarkBoolean(z)
+	return z
+}
+
+func xor3Hint(_ *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) != 3 || len(outputs) != 1 {
+		return errors.New("expecting three inputs and one output")
+	}
+	outputs[0].SetUint64(uint64(inputs[0].Bit(0) ^ inputs[1].Bit(0) ^ inputs[2].Bit(0)))
+	return nil
+}
+
+func chiHint(_ *big.Int, inputs, outputs []*big.Int) error {
+	if len(inputs) != 3 || len(outputs) != 1 {
+		return errors.New("expecting three inputs and one output")
+	}
+	a := inputs[0].Bit(0)
+	b := inputs[1].Bit(0)
+	c := inputs[2].Bit(0)
+	outputs[0].SetUint64(uint64(a ^ ((1 ^ b) & c)))
+	return nil
 }


### PR DESCRIPTION
# Description

The circuit implements only the 1600-bit permutation. Hash functions such as SHA3 and SHAKE wrap this permutation in a sponge construction and add padding, domain separation, absorbing, and squeezing logic.

This PR ports some of https://zk.golf/challenges/keccak-f1600 optimizations.

Keccak-f[1600] operates on a 1600-bit state arranged as 25 lanes of 64 bits:

```text
A[x, y][z], where x in [0, 4], y in [0, 4], z in [0, 63]
```

The gnark implementation stores these lanes in row-major form:

```text
state[x + 5*y][z] == A[x, y][z]
```

The permutation has 24 rounds. Each round applies five steps.

### theta

Theta mixes each lane with the parity of neighboring columns.

```text
C[x]    = A[x,0] xor A[x,1] xor A[x,2] xor A[x,3] xor A[x,4]
D[x]    = C[x-1] xor ROT(C[x+1], 1)
A[x,y]  = A[x,y] xor D[x]
```

All `x` indices are modulo 5. Lane rotations are modulo 64.

### rho and pi

Rho rotates each lane by a fixed offset. Pi permutes the lane positions.

In a circuit these steps are almost free: they are wire rewrites. No boolean operation has to be constrained when a lane is only moved or its bits are re-indexed.

### chi

Chi is the only nonlinear step. It updates each row with a bitwise expression:

```text
A[x,y] = A[x,y] xor ((not A[x+1,y]) and A[x+2,y])
```

This is the expensive part in a naive circuit because it combines XOR, NOT, and AND on every bit of every lane in every round.

### iota

Iota xors a round constant into lane `A[0,0]`.

For bits, xoring by a constant 1 is `1 - bit`; xoring by 0 does nothing. Like rho and pi, this does not need a multiplication row when the bit is already known to be boolean.

## Previous gnark implementation

The public API is:

```go
func Permute(uapi *uints.BinaryField[uints.U64], input [25]uints.U64) [25]uints.U64
```

The previous implementation kept the state as `[25]uints.U64` and expressed the round function with the byte-oriented `uints` API:

```text
theta: uapi.Xor(...)
rho:   uapi.Lrot(...)
chi:   uapi.Xor(a, uapi.And(uapi.Not(b), c))
iota:  uapi.Xor(a, roundConstant)
```

This style is compact and easy to audit, but it pays for general byte lookups and byte-level bitwise operations. Keccak is naturally a bit circuit: all useful work is XOR, AND, NOT, rotation, and lane rewiring. The optimized implementation therefore moves the permutation core from byte-level lanes to bit-level lanes.

## Optimized gnark implementation

The exported API is unchanged. `Permute` now:

1. Decomposes each `uints.U64` lane into 64 little-endian bits.
2. Applies an internal bit-level permutation.
3. Packs the 64 output bits of each lane back into `uints.U64`.

The implementation chooses between two internal paths:

```text
R1CS path:     custom one-row identities for xor3 and chi
generic path:  frontend bit operations, with an SCS-specific and-not row
```

The R1CS path is selected only when the compiler exposes R1CS linear expressions and the field characteristic is greater than 3. The characteristic condition matters because the custom identities rely on small nonzero factors.

Hints are used to assign the output bit of the custom rows. The rows themselves constrain the hinted value, so the hints are not trusted.

## zk.golf optimizations

The zk.golf Keccak-f[1600] record submission uses two main ideas:

1. Replace pairwise XOR chains with one-row three-input XOR.
2. Replace chi with one row per output bit.

As of 2026-07-30, the record submission for the zk.golf `keccak-f1600` challenge reports:

```text
constraints:  92160
allocations:  92160
score:        184320
```

The same core row count appears in gnark's internal R1CS bit permutation. The exported gnark `Permute` count is higher because it also includes the `uints.U64` API boundary: input byte decomposition, output byte packing, and output equality
in the count test.

### One-row xor3

For boolean inputs `a`, `b`, `c`, the R1CS path computes:

```text
z = a xor b xor c
```

with one rank-1 row:

```text
(z + 2a + 2b + 7c) * (a + b - 4c + 1) = 6a + 6b - 24c
```

For boolean `a`, `b`, and `c`, and characteristic greater than 3, the right factor is never zero on the boolean cube. That makes the equation uniquely pin `z` to `a xor b xor c`.

This improves theta. A five-input column parity is computed with two `xor3` rows:

```text
t    = xor3(A[x,0], A[x,1], A[x,2])
C[x] = xor3(t,      A[x,3], A[x,4])
```

Then the normal theta update:

```text
A[x,y] = A[x,y] xor C[x-1] xor ROT(C[x+1], 1)
```

is applied directly with one more `xor3` row. There is no separate `D[x]` variable.

Per round, theta costs:

```text
column parity: 5 columns * 64 bits * 2 rows  =   640
D folding:     25 lanes  * 64 bits * 1 row   =  1600
theta total:                                      2240
```

### One-row chi

For boolean inputs `a`, `b`, `c`, chi computes:

```text
z = a xor ((not b) and c)
```

with one rank-1 row:

```text
(z + 3a - b - c) * (4a + b + c - 3) = 4a + 2b
```

For boolean `a`, `b`, and `c`, and characteristic greater than 3, the second factor is nonzero on the boolean cube. The row therefore uniquely pins `z` to the chi output bit.

Per round, chi costs:

```text
25 lanes * 64 bits * 1 row = 1600
```

### R1CS core count

Rho, pi, and iota are rewiring or constant bit flips. The optimized R1CS core therefore has only theta and chi rows:

```text
theta: 2240 rows/round
chi:   1600 rows/round
total: 3840 rows/round

3840 rows/round * 24 rounds = 92160 rows
```

The exported gnark count for one permutation plus output equality is:

```text
R1CS constraints: 94160
SCS constraints:  158486
```

The R1CS difference from `92160` is the public `uints.U64` boundary around the core, not extra permutation logic.

## SCS notes

The current SCS frontend exposes rows of the form:

```text
qL*a + qR*b + qO*o + qM*a*b + qC = 0
```

This is enough to optimize:

```text
z = (not b) and c = c - b*c
```

as one SCS row:

```text
b*c - c + z = 0
```

The generic path uses that row for the `and-not` subexpression in chi.

The zk.golf `xor3` and one-row chi identities multiply wider linear expressions involving more than the three SCS row variables. Transplanting them directly into gnark SCS would require additional gate or blueprint support; doing it with the current three-slot row shape would introduce temporary variables and lose the intended savings.

## Sources

- NIST FIPS 202, SHA-3 Standard: https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.202.pdf
- zk.golf Keccak-f[1600] challenge: https://zk.golf/challenges/keccak-f1600
- zk.golf Keccak-f[1600] leaderboard API: https://zk.golf/api/agent/v1/challenges/keccak-f1600/leaderboard
- zk.golf record submission metadata: https://zk.golf/api/agent/v1/submissions/5bdce6d5-90a2-4208-bee3-0924b20ccb3b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large rewrite of a cryptographic permutation with custom R1CS rows and hints; soundness depends on the boolean identities and hint wiring, though the public API is unchanged and correctness tests remain.
> 
> **Overview**
> **Reimplements KeccakF-1600 in-circuit for much lower constraint cost** while keeping `Permute`’s public API unchanged. Lanes are converted to 64-bit little-endian state, permuted at the bit level, then packed back to `uints.U64`.
> 
> On **R1CS** (field characteristic &gt; 3), theta and chi use zk.golf-style **single-row** `xor3` and `chi` gadgets with hinted outputs and `BlueprintGenericR1C` instructions; documented cost drops to ~94k Groth16 / ~158k Plonk constraints per permutation (from ~194k / ~292k). **Plonk and tiny fields** use a generic bit path (including a Plonk-specific `(NOT b) AND c` row for chi).
> 
> Supporting changes: **`uints`** gains `ToBits` / `FromBits` and `BinaryField.API()` for the bit boundary; **`std.RegisterHints`** registers `keccakf` hints for serialized constraint systems. Tests add a `U64` bits round-trip and R1CS/SCS constraint logging for one permutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7e02fbe6ee0d0e52aebac8219a00686b147fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->