### PR TITLE
fix: handle non-modulus-width elements in emulated IsZero

### DIFF
--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -1308,29 +1308,40 @@ func testIsZeroNonModulusWidth[T FieldParams](t *testing.T) {
 	var fp T
 	p := fp.Modulus()
 	assert := test.NewAssert(t)
-	assert.Run(func(assert *test.Assert) {
-		nbWideLimbs := 2 * int(fp.NbLimbs())
-		wide := func(v *big.Int, expected int) *IsZeroEdgeCase[T] {
-			w := &IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, nbWideLimbs), Expected: expected}
-			vlimbs := make([]*big.Int, nbWideLimbs)
-			for i := range vlimbs {
-				vlimbs[i] = new(big.Int)
+	// 2x the modulus limb count, and 8x — for single-limb small-field params
+	// (e.g. Goldilocks) the latter exceeds the native field bit length (a
+	// 512-bit hash output over a 64-bit modulus), so a native recomposition of
+	// the limbs would wrap.
+	for _, mult := range []int{2, 8} {
+		nbWideLimbs := mult * int(fp.NbLimbs())
+		assert.Run(func(assert *test.Assert) {
+			wide := func(v *big.Int, expected int) *IsZeroEdgeCase[T] {
+				w := &IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, nbWideLimbs), Expected: expected}
+				vlimbs := make([]*big.Int, nbWideLimbs)
+				for i := range vlimbs {
+					vlimbs[i] = new(big.Int)
+				}
+				err := limbs.Decompose(v, fp.BitsPerLimb(), vlimbs)
+				assert.NoError(err)
+				for i := range vlimbs {
+					w.Limbs[i] = vlimbs[i]
+				}
+				return w
 			}
-			err := limbs.Decompose(v, fp.BitsPerLimb(), vlimbs)
-			assert.NoError(err)
-			for i := range vlimbs {
-				w.Limbs[i] = vlimbs[i]
-			}
-			return w
-		}
-		pSquared := new(big.Int).Mul(p, p)
-		assert.CheckCircuit(&IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, nbWideLimbs)},
-			test.WithValidAssignment(wide(new(big.Int).Lsh(p, 1), 1)),                    // 2p == 0 mod p, but 2p is outside the 0-or-p range
-			test.WithValidAssignment(wide(pSquared, 1)),                                  // p^2 == 0 mod p, occupies the high limbs
-			test.WithValidAssignment(wide(new(big.Int).Add(pSquared, big.NewInt(5)), 0)), // p^2 + 5 == 5 mod p
-			test.WithValidAssignment(wide(big.NewInt(0), 1)),
-		)
-	}, testName[T]())
+			pSquared := new(big.Int).Mul(p, p)
+			// a multiple of p that occupies the top limb of the wide element
+			topShift := uint(nbWideLimbs)*fp.BitsPerLimb() - uint(p.BitLen()) - 2
+			pTop := new(big.Int).Lsh(p, topShift)
+			assert.CheckCircuit(&IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, nbWideLimbs)},
+				test.WithValidAssignment(wide(new(big.Int).Lsh(p, 1), 1)),                    // 2p == 0 mod p, but 2p is outside the 0-or-p range
+				test.WithValidAssignment(wide(pSquared, 1)),                                  // p^2 == 0 mod p
+				test.WithValidAssignment(wide(new(big.Int).Add(pSquared, big.NewInt(5)), 0)), // p^2 + 5 == 5 mod p
+				test.WithValidAssignment(wide(pTop, 1)),                                      // p*2^k == 0 mod p, occupies the high limbs
+				test.WithValidAssignment(wide(new(big.Int).Add(pTop, big.NewInt(5)), 0)),     // p*2^k + 5 == 5 mod p
+				test.WithValidAssignment(wide(big.NewInt(0), 1)),
+			)
+		}, testName[T](), fmt.Sprintf("wide=%d", mult))
+	}
 	assert.Run(func(assert *test.Assert) {
 		plimbs := make([]*big.Int, int(fp.NbLimbs()))
 		for i := range plimbs {

--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -1294,6 +1294,69 @@ func TestIsZeroEdgeCases(t *testing.T) {
 	testIsZeroEdgeCases[emparams.Mod1e512](t)
 }
 
+// testIsZeroNonModulusWidth checks IsZero on elements whose limb count differs
+// from the modulus width. Such elements have zero overflow, so [Field.Reduce]
+// passes them through unchanged:
+//   - wider than the modulus (e.g. a [Field.FromBits] result over a hash
+//     output twice the modulus bit length): the value may be a multiple of p
+//     larger than 2p, which the 0-or-p comparison cannot classify — and the
+//     limb-wise comparison against the modulus indexed out of range.
+//   - narrower than the modulus: the comparison checked only the given prefix
+//     of the modulus limbs, returning a false positive for an element equal
+//     to the low limbs of p.
+func testIsZeroNonModulusWidth[T FieldParams](t *testing.T) {
+	var fp T
+	p := fp.Modulus()
+	assert := test.NewAssert(t)
+	assert.Run(func(assert *test.Assert) {
+		nbWideLimbs := 2 * int(fp.NbLimbs())
+		wide := func(v *big.Int, expected int) *IsZeroEdgeCase[T] {
+			w := &IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, nbWideLimbs), Expected: expected}
+			vlimbs := make([]*big.Int, nbWideLimbs)
+			for i := range vlimbs {
+				vlimbs[i] = new(big.Int)
+			}
+			err := limbs.Decompose(v, fp.BitsPerLimb(), vlimbs)
+			assert.NoError(err)
+			for i := range vlimbs {
+				w.Limbs[i] = vlimbs[i]
+			}
+			return w
+		}
+		pSquared := new(big.Int).Mul(p, p)
+		assert.CheckCircuit(&IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, nbWideLimbs)},
+			test.WithValidAssignment(wide(new(big.Int).Lsh(p, 1), 1)),                    // 2p == 0 mod p, but 2p is outside the 0-or-p range
+			test.WithValidAssignment(wide(pSquared, 1)),                                  // p^2 == 0 mod p, occupies the high limbs
+			test.WithValidAssignment(wide(new(big.Int).Add(pSquared, big.NewInt(5)), 0)), // p^2 + 5 == 5 mod p
+			test.WithValidAssignment(wide(big.NewInt(0), 1)),
+		)
+	}, testName[T]())
+	assert.Run(func(assert *test.Assert) {
+		plimbs := make([]*big.Int, int(fp.NbLimbs()))
+		for i := range plimbs {
+			plimbs[i] = new(big.Int)
+		}
+		err := limbs.Decompose(p, fp.BitsPerLimb(), plimbs)
+		assert.NoError(err)
+		if fp.NbLimbs() == 1 || plimbs[0].Sign() == 0 {
+			// a single-limb prefix of p is only a counterexample when it is a
+			// strict, non-zero prefix
+			return
+		}
+		// a single-limb element equal to the lowest limb of p is not zero
+		// mod p, but a prefix-only comparison would claim it is
+		assert.CheckCircuit(&IsZeroEdgeCase[T]{Limbs: make([]frontend.Variable, 1)},
+			test.WithValidAssignment(&IsZeroEdgeCase[T]{Limbs: []frontend.Variable{plimbs[0]}, Expected: 0}),
+		)
+	}, testName[T]())
+}
+
+func TestIsZeroNonModulusWidth(t *testing.T) {
+	testIsZeroNonModulusWidth[Goldilocks](t)
+	testIsZeroNonModulusWidth[BN254Fr](t)
+	testIsZeroNonModulusWidth[emparams.Mod1e512](t)
+}
+
 type PolyEvalCircuit[T FieldParams] struct {
 	Inputs         []Element[T]
 	TermsByIndices [][]int

--- a/std/math/emulated/element_test.go
+++ b/std/math/emulated/element_test.go
@@ -1357,6 +1357,55 @@ func TestIsZeroNonModulusWidth(t *testing.T) {
 	testIsZeroNonModulusWidth[emparams.Mod1e512](t)
 }
 
+// IsZeroConstWideCircuit builds wide elements out of compile-time constant
+// limbs, the case where the reduction inside IsZero folds to a constant
+// element whose limb count depends on the reduced value (zero limbs for 0).
+type IsZeroConstWideCircuit[T FieldParams] struct {
+	Dummy frontend.Variable
+}
+
+func (c *IsZeroConstWideCircuit[T]) Define(api frontend.API) error {
+	var fp T
+	f, err := NewField[T](api)
+	if err != nil {
+		return err
+	}
+	constWide := func(v *big.Int) *Element[T] {
+		vlimbs := make([]*big.Int, 2*int(fp.NbLimbs()))
+		for i := range vlimbs {
+			vlimbs[i] = new(big.Int)
+		}
+		if err := limbs.Decompose(v, fp.BitsPerLimb(), vlimbs); err != nil {
+			panic(err)
+		}
+		lvars := make([]frontend.Variable, len(vlimbs))
+		for i := range vlimbs {
+			lvars[i] = vlimbs[i]
+		}
+		return f.newInternalElement(lvars, 0)
+	}
+	twoP := new(big.Int).Lsh(fp.Modulus(), 1)
+	api.AssertIsEqual(f.IsZero(constWide(twoP)), 1)
+	api.AssertIsEqual(f.IsZero(constWide(new(big.Int).Add(twoP, big.NewInt(5)))), 0)
+	api.AssertIsEqual(c.Dummy, 0)
+	return nil
+}
+
+func testIsZeroConstWide[T FieldParams](t *testing.T) {
+	assert := test.NewAssert(t)
+	assert.Run(func(assert *test.Assert) {
+		assert.CheckCircuit(&IsZeroConstWideCircuit[T]{},
+			test.WithValidAssignment(&IsZeroConstWideCircuit[T]{Dummy: 0}),
+		)
+	}, testName[T]())
+}
+
+func TestIsZeroConstWide(t *testing.T) {
+	testIsZeroConstWide[Goldilocks](t)
+	testIsZeroConstWide[BN254Fr](t)
+	testIsZeroConstWide[emparams.Mod1e512](t)
+}
+
 type PolyEvalCircuit[T FieldParams] struct {
 	Inputs         []Element[T]
 	TermsByIndices [][]int

--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -164,6 +164,15 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 	// correspond to the modulus limbs.
 	ca := f.Reduce(a)
 	p := f.Modulus()
+	if len(ca.Limbs) > len(p.Limbs) {
+		// [Field.Reduce] does not reduce zero-overflow elements even when they
+		// are wider than the modulus (e.g. a [Field.FromBits] result over more
+		// bits than the modulus width). Such a value is not bounded by 2p, so
+		// the 0-or-p check below would misclassify multiples of p — and the
+		// limb-wise comparison against the modulus would index out of range.
+		// Force a full modular reduction to the modulus width first.
+		ca = f.mulMod(ca, f.One(), 0, nil)
+	}
 
 	// we use two approaches for checking if the element is exactly zero. The
 	// first approach is to check that every limb individually is zero. The
@@ -194,9 +203,18 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 	// however, for checking if the element is p, we can not use the
 	// optimization as we may have underflows. So we have to check every limb
 	// individually.
+	// the element may have fewer limbs than the modulus (e.g. a short
+	// [Field.FromBits] result), in which case the missing high limbs are zero.
+	// We must still compare against every modulus limb — comparing only the
+	// prefix would return a false positive for an element equal to the low
+	// limbs of p.
 	resP := f.api.IsZero(f.api.Sub(p.Limbs[0], ca.Limbs[0]))
-	for i := 1; i < len(ca.Limbs); i++ {
-		resP = f.api.Mul(resP, f.api.IsZero(f.api.Sub(p.Limbs[i], ca.Limbs[i])))
+	for i := 1; i < len(p.Limbs); i++ {
+		var caLimb frontend.Variable = 0
+		if i < len(ca.Limbs) {
+			caLimb = ca.Limbs[i]
+		}
+		resP = f.api.Mul(resP, f.api.IsZero(f.api.Sub(p.Limbs[i], caLimb)))
 	}
 	return f.api.Or(res0, resP)
 }

--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -2,6 +2,8 @@ package emulated
 
 import (
 	"fmt"
+	"math/big"
+	"math/bits"
 
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/profile"
@@ -182,6 +184,28 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 		// the 0-or-p check below would misclassify multiples of p — and the
 		// limb-wise comparison against the modulus would index out of range.
 		// Force a full modular reduction to the modulus width first.
+		if f.useSmallFieldOptimization() {
+			// In small-field mode mulMod flattens multi-limb inputs through a
+			// plain native recomposition (toSingleLimbElement), which wraps in
+			// the native field once the element is wider than the native
+			// modulus and understates the overflow either way. Fold the limbs
+			// with mod-p-reduced coefficients instead: the result is congruent
+			// mod p, fits the native field by the small-field-mode invariant,
+			// and carries an honest overflow for the reduction below.
+			pv := f.fParams.Modulus()
+			base := new(big.Int).Lsh(big.NewInt(1), f.fParams.BitsPerLimb())
+			base.Mod(base, pv)
+			coef := new(big.Int).Set(base)
+			acc := ca.Limbs[0]
+			for i := 1; i < len(ca.Limbs); i++ {
+				acc = f.api.MulAcc(acc, ca.Limbs[i], new(big.Int).Set(coef))
+				coef.Mul(coef, base).Mod(coef, pv)
+			}
+			// value < n * 2^(w+overflow) * p, i.e. the single limb is bounded
+			// by 2^(w + overflow + pBits + ceil(log2(n)))
+			foldOverflow := ca.overflow + uint(pv.BitLen()) + uint(bits.Len(uint(len(ca.Limbs))))
+			ca = f.newInternalElement([]frontend.Variable{acc}, foldOverflow)
+		}
 		ca = f.mulMod(ca, f.One(), 0, nil)
 	}
 

--- a/std/math/emulated/field_assert.go
+++ b/std/math/emulated/field_assert.go
@@ -155,6 +155,17 @@ func (f *Field[T]) IsZero(a *Element[T]) frontend.Variable {
 	if a.isStrictZero() {
 		return 1
 	}
+	// fast path - when the element is constant, evaluate at compile time. This
+	// also keeps constant elements out of the reduction below: for a constant
+	// wider than the modulus it would fold to a constant element whose limb
+	// count depends on the reduced value (zero limbs for 0 mod p), which the
+	// limb-indexing below cannot handle.
+	if cv, cConst := f.constantValue(a); cConst {
+		if cv.Mod(cv, f.fParams.Modulus()).Sign() == 0 {
+			return 1
+		}
+		return 0
+	}
 
 	// to avoid using strict reduction (which is expensive as requires binary
 	// assertion that value is less than modulus), we use ordinary reduction but


### PR DESCRIPTION
# Description

`emulated.Field.IsZero` assumed the element it reduces always comes back with exactly the modulus limb count. Elements built by `Field.FromBits` can legally carry a different number of limbs with zero overflow, and `Field.Reduce`'s fast path returns zero-overflow elements unchanged regardless of width. This broke `IsZero` in two ways:

- **Wider than the modulus** (e.g. a 512-bit `FromBits` result over a 4-limb modulus): the limb-wise `ca == p` comparison indexed out of range and panicked at circuit definition (`index out of range [4] with length 4`). This is reachable from std: `scalarMulFakeGLV` calls `IsZero(s)` on the incoming scalar, so passing a wide `FromBits` scalar (e.g. a SHA-512 output for Ed25519-style verification) into `ScalarMul`/`MultiScalarMul` on a fakeGLV curve crashes at compile time. Additionally, such a value is not bounded by `2p`, so the 0-or-p classification would misclassify multiples of `p` (`2p`, `p²`, …) as non-zero even without the panic.
- **Narrower than the modulus**: the comparison loop only checked the given prefix of `p.Limbs`, returning a false positive (`IsZero == 1`) for a non-zero element equal to the low limbs of `p`.

The fix forces a full modular reduction to the modulus width when the reduced element is wider than the modulus (one `mulMod` by one, only on this path), and compares against every modulus limb, treating missing high limbs as zero, when it is narrower.

An alternative would be to tighten `Reduce`'s fast path itself (require `len(a.Limbs) <= NbLimbs` in addition to `overflow == 0`); that touches every consumer, so this PR keeps the change local to `IsZero`. Happy to rework in that direction if preferred.

Fixes #1805

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

- [x] New `TestIsZeroNonModulusWidth` (Goldilocks, BN254Fr, Mod1e512) covering: `2p` and `p²` as wide zero-overflow elements (`≡ 0 mod p`), `p² + 5` (non-zero), zero, and a single-limb element equal to the low limb of `p` (non-zero, previously a false positive). The wide cases panic and the narrow case fails before this fix.
- [x] `go test ./std/math/emulated/...` passes locally.

# How has this been benchmarked?

- [ ] Not benchmarked — the new `mulMod` reduction only triggers for elements wider than the modulus, which previously panicked; the width-matched path adds no constraints. The narrow-element path adds `len(p.Limbs) - len(ca.Limbs)` IsZero gates only for narrow elements.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I did not modify files generated from templates
- [ ] `golangci-lint` does not output errors locally (not installed here; `gofmt` and `go vet` are clean)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness fix in a core emulated-field primitive used by scalar multiplication; wrong `IsZero` results can break circuit soundness. Change is localized to `IsZero` and covered by new tests.
> 
> **Overview**
> Fixes `Field.IsZero` for elements whose limb count differs from the modulus (e.g. `FromBits` results). `Reduce`'s zero-overflow fast path left these unchanged, so the 0-or-p check either **panicked** on wide elements or returned **false positives** on narrow ones.
> 
> **Wider than modulus:** force a full `mulMod` reduction first (with a small-field fold that avoids native wraparound). Also short-circuits constant elements at compile time.
> 
> **Narrower than modulus:** compare against every modulus limb, treating missing high limbs as zero.
> 
> Adds edge-case tests covering `2p`, `p²`, high-limb multiples, and single-limb prefixes of `p`, plus constant-wide elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a23d8b2b52048307d2f8e594cbbdda79956d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->