### PR TITLE
test: make constness a property of the value in the test engine

### DIFF
--- a/std/math/bits/engine_constness_test.go
+++ b/std/math/bits/engine_constness_test.go
@@ -1,6 +1,7 @@
 package bits_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -209,5 +210,45 @@ func TestConstnessPropagates(t *testing.T) {
 	}
 	if !lit {
 		t.Error("1 + 2 must read as constant")
+	}
+}
+
+// mulProbe records the constness of a product where one operand is a witness whose
+// solved value lands on the two cases Mul has an allocation shortcut for.
+type mulProbe struct {
+	Witness frontend.Variable `gnark:",public"`
+	byWit   *bool
+	byConst *bool
+}
+
+func (c *mulProbe) Define(api frontend.API) error {
+	_, w := api.Compiler().ConstantValue(api.Mul(frontend.Variable(7), c.Witness))
+	_, k := api.Compiler().ConstantValue(api.Mul(frontend.Variable(7), frontend.Variable(1)))
+	*c.byWit, *c.byConst = w, k
+	return nil
+}
+
+// TestMulShortcutDoesNotOverClaim covers the allocation shortcut in Mul, which returns
+// before taint and so used to decide constness from the runtime value of its second
+// operand. A witness that solves to 0 came back as the Go literal 0 and read as
+// constant; a witness that solves to 1 came back as i1 and inherited i1's constness.
+// Neither builder can fold a product of two variables, so both were over-claims.
+func TestMulShortcutDoesNotOverClaim(t *testing.T) {
+	for _, solved := range []int{0, 1} {
+		t.Run(fmt.Sprintf("witness=%d", solved), func(t *testing.T) {
+			var byWit, byConst bool
+			if err := test.IsSolved(
+				&mulProbe{byWit: &byWit, byConst: &byConst},
+				&mulProbe{Witness: solved}, ecc.BN254.ScalarField(),
+			); err != nil {
+				t.Fatal(err)
+			}
+			if byWit {
+				t.Errorf("7 * witness read as constant when the witness solves to %d", solved)
+			}
+			if !byConst {
+				t.Error("7 * 1 must still read as constant")
+			}
+		})
 	}
 }

--- a/std/math/bits/engine_constness_test.go
+++ b/std/math/bits/engine_constness_test.go
@@ -1,0 +1,213 @@
+package bits_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/consensys/gnark/std/math/bits"
+	"github.com/consensys/gnark/test"
+)
+
+// Regression cover for issue #650. The test engine used to answer ConstantValue
+// from a single engine-wide flag rather than from the value, so it could not model
+// a circuit mixing witness inputs and constants.
+//
+// The consequence was stronger than losing context: for the same circuit the test
+// engine and the compiler took different branches, so a check that fires during
+// compilation was unreachable from a test-engine test. Both tests below fail on
+// master and pass once constness is a property of the value.
+//
+// Results are reported through pointer fields, which survive the circuit copy that
+// IsSolved performs. Writing to a plain bool field does not come back.
+
+type constnessProbe struct {
+	Witness      frontend.Variable `gnark:",public"`
+	witnessConst *bool
+	literalConst *bool
+}
+
+func (c *constnessProbe) Define(api frontend.API) error {
+	_, w := api.Compiler().ConstantValue(c.Witness)
+	_, l := api.Compiler().ConstantValue(frontend.Variable(3))
+	if c.witnessConst != nil {
+		*c.witnessConst = w
+	}
+	if c.literalConst != nil {
+		*c.literalConst = l
+	}
+	return nil
+}
+
+// TestConstnessIsUniformAcrossTheEngine shows the flag is global, not per value.
+// Two configurations exist and neither can express a mixed circuit: the default
+// reports everything non-constant, including a literal, and the option reports
+// everything constant, including a genuine witness.
+func TestConstnessIsUniformAcrossTheEngine(t *testing.T) {
+	var defW, defL, allW, allL bool
+
+	if err := test.IsSolved(
+		&constnessProbe{witnessConst: &defW, literalConst: &defL},
+		&constnessProbe{Witness: 1}, ecc.BN254.ScalarField(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := test.IsSolved(
+		&constnessProbe{witnessConst: &allW, literalConst: &allL},
+		&constnessProbe{Witness: 1}, ecc.BN254.ScalarField(),
+		test.SetAllVariablesAsConstants(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("default engine:                 witness=%v literal=%v", defW, defL)
+	t.Logf("SetAllVariablesAsConstants:     witness=%v literal=%v", allW, allL)
+
+	// A mixed circuit must report mixed. On master both values come back the same,
+	// because the answer is read from an engine-wide flag rather than the value.
+	if defW {
+		t.Error("a witness should not read as constant under the default engine")
+	}
+	if !defL {
+		t.Error("a Go literal should read as constant; on master it does not, which is the defect")
+	}
+	if defW == defL {
+		t.Error("default engine could not distinguish a witness from a literal")
+	}
+
+	// The legacy option keeps its documented meaning: everything reads as constant.
+	if !allW || !allL {
+		t.Errorf("SetAllVariablesAsConstants should force both to constant, got witness=%v literal=%v", allW, allL)
+	}
+}
+
+// wideDigit feeds FromBinary a literal 2, which is more than one bit.
+type wideDigit struct {
+	X frontend.Variable `gnark:",public"`
+}
+
+func (c *wideDigit) Define(api frontend.API) error {
+	api.AssertIsEqual(c.X, c.X)
+	_ = bits.FromBinary(api, []frontend.Variable{frontend.Variable(2), frontend.Variable(0)})
+	return nil
+}
+
+// TestCompilerAndEngineTakeDifferentBranches is the finding.
+//
+// fromBinary has two branches. The all-constant branch folds the digits and rejects
+// any digit wider than one bit. The general branch instead calls AssertIsBoolean on
+// each digit. The two therefore fail with different messages, which makes the branch
+// taken observable.
+//
+// Compiling reaches the constant branch. The test engine reaches the general one,
+// for the identical circuit, because ConstantValue reports false for every value.
+func TestCompilerAndEngineTakeDifferentBranches(t *testing.T) {
+	var compileErr string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				compileErr = "panic: " + toString(r)
+			}
+		}()
+		if _, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, &wideDigit{}); err != nil {
+			compileErr = err.Error()
+		}
+	}()
+
+	var engineErr string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				engineErr = "panic: " + toString(r)
+			}
+		}()
+		if err := test.IsSolved(&wideDigit{}, &wideDigit{X: 1}, ecc.BN254.ScalarField()); err != nil {
+			engineErr = err.Error()
+		}
+	}()
+
+	t.Logf("compiler:    %s", orNone(compileErr))
+	t.Logf("test engine: %s", orNone(engineErr))
+
+	constantBranch := strings.Contains(compileErr, "more than 1 bit")
+	if !constantBranch {
+		t.Fatalf("expected the compiler to reach the constant-folding branch, got: %s", orNone(compileErr))
+	}
+
+	// The test engine must reach the same branch as the compiler. On master it does
+	// not: it reports [assertIsBoolean] 2 from the general branch instead.
+	if !strings.Contains(engineErr, "more than 1 bit") {
+		t.Errorf("test engine took a different branch from the compiler, got: %s", orNone(engineErr))
+	}
+}
+
+func toString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if e, ok := v.(error); ok {
+		return e.Error()
+	}
+	return "non-string panic"
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(no error)"
+	}
+	return s
+}
+
+// derivedProbe records constness of values DERIVED from a witness rather than of
+// the witness itself.
+type derivedProbe struct {
+	Witness frontend.Variable `gnark:",public"`
+	sum     *bool
+	bit     *bool
+	lit     *bool
+}
+
+func (c *derivedProbe) Define(api frontend.API) error {
+	_, s := api.Compiler().ConstantValue(api.Add(c.Witness, 1))
+	_, l := api.Compiler().ConstantValue(api.Add(frontend.Variable(1), frontend.Variable(2)))
+	_, b := api.Compiler().ConstantValue(api.ToBinary(c.Witness, 8)[0])
+	*c.sum, *c.lit, *c.bit = s, l, b
+	return nil
+}
+
+// TestConstnessPropagates covers the direction that is easy to get wrong.
+//
+// Constness has to travel with the value through every operation that produces one.
+// Two failures are possible and only one of them is safe:
+//
+//	under-claiming  a constant reads as non-constant, the engine takes the general
+//	                branch, which is what master already does
+//	over-claiming   a value derived from a witness reads as constant, the engine
+//	                folds something the compiler cannot, and a test passes on a
+//	                circuit that will not compile
+//
+// The ToBinary case is the trap. Its bits used to be plain Go uints, and a uint
+// reaches the engine through the same path as a written literal, so every bit of a
+// witness would have read as constant.
+func TestConstnessPropagates(t *testing.T) {
+	var sum, bit, lit bool
+	if err := test.IsSolved(
+		&derivedProbe{sum: &sum, bit: &bit, lit: &lit},
+		&derivedProbe{Witness: 7}, ecc.BN254.ScalarField(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if sum {
+		t.Error("witness + 1 must not read as constant")
+	}
+	if bit {
+		t.Error("a bit of ToBinary(witness) must not read as constant")
+	}
+	if !lit {
+		t.Error("1 + 2 must read as constant")
+	}
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -232,7 +232,11 @@ func (e *engine) Neg(i1 frontend.Variable) frontend.Variable {
 func (e *engine) Mul(i1, i2 frontend.Variable, in ...frontend.Variable) frontend.Variable {
 	atomic.AddUint64(&cptMul, 1)
 	b2 := e.toBigInt(i2)
-	if len(in) == 0 && b2.IsUint64() && b2.Uint64() <= 1 {
+	// The allocation shortcut returns before taint, so it may only be taken when i2 is
+	// genuinely constant. Gated on the runtime value alone, a witness that happens to
+	// solve to 0 or 1 would make the product read as constant, which is the over-claim
+	// this file exists to avoid: neither builder can fold a product of two variables.
+	if len(in) == 0 && e.isConstValue(i2) && b2.IsUint64() && b2.Uint64() <= 1 {
 		// special path to avoid useless allocations
 		if b2.Uint64() == 0 {
 			return 0

--- a/test/engine.go
+++ b/test/engine.go
@@ -41,6 +41,18 @@ type engine struct {
 	q       *big.Int // field modulus
 	// mHintsFunctions map[hint.ID]hintFunction
 	constVars bool
+	// constant records which values are known to be constants. Constness is a
+	// property of the value, so it cannot be answered by a single engine-wide flag:
+	// a circuit can mix witness inputs and constants, and the compiler distinguishes
+	// them.
+	//
+	// Absent means NON-constant, deliberately. Every operation that produces a value
+	// must opt its result in, and there are around twenty-five of them. If one is
+	// missed, the result degrades to non-constant, which is what master already
+	// reports. The opposite default fails open: a witness-derived value that slipped
+	// through an untracked operation would be announced as a constant, and callers
+	// branch on that.
+	constant map[*big.Int]struct{}
 	kvstore.Store
 	blueprints                []constraint.Blueprint
 	internalVariables         []*big.Int
@@ -101,6 +113,7 @@ func IsSolved(circuit, witness frontend.Circuit, field *big.Int, opts ...TestEng
 		curveID:   utils.FieldToCurve(field),
 		q:         new(big.Int).Set(field),
 		constVars: false,
+		constant:  make(map[*big.Int]struct{}),
 		Store:     kvstore.New(),
 	}
 	for _, opt := range opts {
@@ -182,7 +195,7 @@ func (e *engine) Add(i1, i2 frontend.Variable, in ...frontend.Variable) frontend
 		res.Add(res, e.toBigInt(in[i]))
 	}
 	res.Mod(res, e.modulus())
-	return res
+	return e.taint(res, append([]frontend.Variable{i1, i2}, in...)...)
 }
 
 func (e *engine) MulAcc(a, b, c frontend.Variable) frontend.Variable {
@@ -194,7 +207,7 @@ func (e *engine) MulAcc(a, b, c frontend.Variable) frontend.Variable {
 	res.Add(_a, bc).Mod(res, e.modulus())
 
 	pool.BigInt.Put(bc)
-	return res
+	return e.taint(res, a, b, c)
 }
 
 func (e *engine) Sub(i1, i2 frontend.Variable, in ...frontend.Variable) frontend.Variable {
@@ -206,14 +219,14 @@ func (e *engine) Sub(i1, i2 frontend.Variable, in ...frontend.Variable) frontend
 		res.Sub(res, e.toBigInt(in[i]))
 	}
 	res.Mod(res, e.modulus())
-	return res
+	return e.taint(res, append([]frontend.Variable{i1, i2}, in...)...)
 }
 
 func (e *engine) Neg(i1 frontend.Variable) frontend.Variable {
 	res := new(big.Int)
 	res.Neg(e.toBigInt(i1))
 	res.Mod(res, e.modulus())
-	return res
+	return e.taint(res, i1)
 }
 
 func (e *engine) Mul(i1, i2 frontend.Variable, in ...frontend.Variable) frontend.Variable {
@@ -235,7 +248,7 @@ func (e *engine) Mul(i1, i2 frontend.Variable, in ...frontend.Variable) frontend
 		res.Mul(res, e.toBigInt(in[i]))
 		res.Mod(res, e.modulus())
 	}
-	return res
+	return e.taint(res, append([]frontend.Variable{i1, i2}, in...)...)
 }
 
 func (e *engine) Div(i1, i2 frontend.Variable) frontend.Variable {
@@ -245,7 +258,7 @@ func (e *engine) Div(i1, i2 frontend.Variable) frontend.Variable {
 	}
 	res.Mul(res, e.toBigInt(i1))
 	res.Mod(res, e.modulus())
-	return res
+	return e.taint(res, i1, i2)
 }
 
 func (e *engine) DivUnchecked(i1, i2 frontend.Variable) frontend.Variable {
@@ -259,7 +272,7 @@ func (e *engine) DivUnchecked(i1, i2 frontend.Variable) frontend.Variable {
 	}
 	res.Mul(res, b1)
 	res.Mod(res, e.modulus())
-	return res
+	return e.taint(res, i1, i2)
 }
 
 func (e *engine) Inverse(i1 frontend.Variable) frontend.Variable {
@@ -267,7 +280,7 @@ func (e *engine) Inverse(i1 frontend.Variable) frontend.Variable {
 	if res.ModInverse(e.toBigInt(i1), e.modulus()) == nil {
 		panic("no inverse")
 	}
-	return res
+	return e.taint(res, i1)
 }
 
 func (e *engine) BatchInvert(in []frontend.Variable) []frontend.Variable {
@@ -281,7 +294,7 @@ func (e *engine) BatchInvert(in []frontend.Variable) []frontend.Variable {
 
 	res := make([]frontend.Variable, len(in))
 	for i := 0; i < len(in); i++ {
-		res[i] = _out[i]
+		res[i] = e.taint(_out[i], in[i])
 	}
 	return res
 }
@@ -343,7 +356,7 @@ func (e *engine) ToBinary(i1 frontend.Variable, n ...int) []frontend.Variable {
 	r := make([]frontend.Variable, nbBits)
 	ri := make([]frontend.Variable, nbBits)
 	for i := 0; i < len(r); i++ {
-		r[i] = (b1.Bit(i))
+		r[i] = e.taint(new(big.Int).SetUint64(uint64(b1.Bit(i))), i1)
 		ri[i] = r[i]
 	}
 
@@ -379,7 +392,7 @@ func (e *engine) FromBinary(v ...frontend.Variable) frontend.Variable {
 	}
 	r.Mod(r, e.modulus())
 
-	return r
+	return e.taint(r, v...)
 }
 
 func (e *engine) Xor(i1, i2 frontend.Variable) frontend.Variable {
@@ -388,7 +401,7 @@ func (e *engine) Xor(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(b2)
 	res := new(big.Int)
 	res.Xor(b1, b2)
-	return res
+	return e.taint(res, i1, i2)
 }
 
 func (e *engine) Or(i1, i2 frontend.Variable) frontend.Variable {
@@ -397,7 +410,7 @@ func (e *engine) Or(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(b2)
 	res := new(big.Int)
 	res.Or(b1, b2)
-	return res
+	return e.taint(res, i1, i2)
 }
 
 func (e *engine) And(i1, i2 frontend.Variable) frontend.Variable {
@@ -406,7 +419,7 @@ func (e *engine) And(i1, i2 frontend.Variable) frontend.Variable {
 	e.mustBeBoolean(b2)
 	res := new(big.Int)
 	res.And(b1, b2)
-	return res
+	return e.taint(res, i1, i2)
 }
 
 // Select if b is true, yields i1 else yields i2
@@ -414,10 +427,12 @@ func (e *engine) Select(b frontend.Variable, i1, i2 frontend.Variable) frontend.
 	b1 := e.toBigInt(b)
 	e.mustBeBoolean(b1)
 
+	chosen := i2
 	if b1.Uint64() == 1 {
-		return e.toBigInt(i1)
+		chosen = i1
 	}
-	return (e.toBigInt(i2))
+	res := new(big.Int).Set(e.toBigInt(chosen))
+	return e.taint(res, b, i1, i2)
 }
 
 // Lookup2 performs a 2-bit lookup between i1, i2, i3, i4 based on bits b0
@@ -430,7 +445,8 @@ func (e *engine) Lookup2(b0, b1 frontend.Variable, i0, i1, i2, i3 frontend.Varia
 	e.mustBeBoolean(s1)
 	lookup := new(big.Int).Lsh(s1, 1)
 	lookup.Or(lookup, s0)
-	return e.toBigInt([]frontend.Variable{i0, i1, i2, i3}[lookup.Uint64()])
+	chosen := e.toBigInt([]frontend.Variable{i0, i1, i2, i3}[lookup.Uint64()])
+	return e.taint(new(big.Int).Set(chosen), b0, b1, i0, i1, i2, i3)
 }
 
 // IsZero returns 1 if a is zero, 0 otherwise
@@ -438,10 +454,10 @@ func (e *engine) IsZero(i1 frontend.Variable) frontend.Variable {
 	b1 := e.toBigInt(i1)
 
 	if b1.IsUint64() && b1.Uint64() == 0 {
-		return big.NewInt(1)
+		return e.taint(big.NewInt(1), i1)
 	}
 
-	return big.NewInt(0)
+	return e.taint(big.NewInt(0), i1)
 }
 
 // Cmp returns 1 if i1>i2, 0 if i1==i2, -1 if i1<i2
@@ -450,7 +466,7 @@ func (e *engine) Cmp(i1, i2 frontend.Variable) frontend.Variable {
 	b2 := e.toBigInt(i2)
 	res := big.NewInt(int64(b1.Cmp(b2)))
 	res.Mod(res, e.modulus())
-	return res
+	return e.taint(res, i1, i2)
 }
 
 func (e *engine) AssertIsEqual(i1, i2 frontend.Variable) {
@@ -585,7 +601,38 @@ func (e *engine) NewHintForId(id solver.HintID, nbOutputs int, inputs ...fronten
 // ConstantValue returns the big.Int value of v
 func (e *engine) ConstantValue(v frontend.Variable) (*big.Int, bool) {
 	r := e.toBigInt(v)
-	return r, e.constVars
+	if e.constVars {
+		// the legacy option still forces everything to read as constant
+		return r, true
+	}
+	_, isConst := e.constant[r]
+	return r, isConst
+}
+
+// taint marks res constant when every operand it was computed from is constant.
+// An operation that never calls this leaves its result non-constant, which is the
+// safe direction.
+func (e *engine) taint(res *big.Int, inputs ...frontend.Variable) *big.Int {
+	if e.constant == nil {
+		e.constant = make(map[*big.Int]struct{})
+	}
+	for _, in := range inputs {
+		if !e.isConstValue(in) {
+			return res
+		}
+	}
+	e.constant[res] = struct{}{}
+	return res
+}
+
+// isConstValue reports whether v is a literal or a value derived only from
+// literals. A Go value that is not a *big.Int reached the engine as a literal.
+func (e *engine) isConstValue(v frontend.Variable) bool {
+	if b, ok := v.(*big.Int); ok {
+		_, isConst := e.constant[b]
+		return isConst
+	}
+	return true
 }
 
 func (e *engine) IsBoolean(v frontend.Variable) bool {
@@ -606,8 +653,13 @@ func (e *engine) toBigInt(i1 frontend.Variable) *big.Int {
 	case big.Int:
 		return &vv
 	default:
+		// anything that is not already a *big.Int arrived as a Go literal
 		b := utils.FromInterface(i1)
 		b.Mod(&b, e.modulus())
+		if e.constant == nil {
+			e.constant = make(map[*big.Int]struct{})
+		}
+		e.constant[&b] = struct{}{}
 		return &b
 	}
 }
@@ -676,8 +728,11 @@ func (e *engine) copyWitness(to, from frontend.Circuit) {
 		if val.Sign() < 0 {
 			val.Add(&val, e.modulus())
 		}
-		wValueReduced := reflect.ValueOf(val)
-		tInput.Set(wValueReduced)
+		// stored as a pointer so the value has a stable identity the engine can
+		// track. As a big.Int value it would be copied into a fresh pointer on
+		// every toBigInt call, and constness could not follow it.
+		pv := new(big.Int).Set(&val)
+		tInput.Set(reflect.ValueOf(pv))
 		i++
 		return nil
 	}


### PR DESCRIPTION
Fixes #650.

The test engine answered `ConstantValue` from an engine-wide flag rather than from the value, so it could not model a circuit that mixes witness inputs with constants. The default reported every value non-constant, including a written literal, and `SetAllVariablesAsConstants` reported every value constant, including a genuine witness.

The consequence is stronger than losing context. For the same circuit the engine and the compiler take different branches, so a check that fires during compilation is unreachable from a test-engine test. `bits.FromBinary` is the example. Compiling a two-bit digit is rejected at `conversion_binary.go:46`:

```
constant input to FromBinary has more than 1 bit. Has 2 bits
```

The test engine never reaches that branch and fails later at `[assertIsBoolean] 2` instead.

## Approach

Constness travels with the value.

```go
constant map[*big.Int]struct{}   // absent means non-constant
```

Absent meaning non-constant is deliberate. An operation that does not propagate degrades to the current behaviour rather than folding something the compiler cannot. There are two ways to be wrong and only one is safe.

| direction | effect |
|---|---|
| under-claiming | a constant reads as non-constant, the engine takes the general branch, which is what `master` already does |
| over-claiming | a value derived from a witness reads as constant, the engine folds what the compiler cannot, and a test passes on a circuit that will not compile |

`copyWitness` now stores `*big.Int` so a value has a stable identity, and `toBigInt` marks written literals constant.

Propagation covers `Add`, `Sub`, `Mul`, `Neg`, `MulAcc`, `Div`, `DivUnchecked`, `Inverse`, `Xor`, `Or`, `And`, `Select`, `Lookup2`, `IsZero`, `Cmp`, `ToBinary`, `FromBinary` and `BatchInvert`. `InternalVariable` is left non-constant since it is a solver wire.

Three cases needed care beyond adding a call:

- `ToBinary` put plain Go `uint`s in its result. A `uint` reaches the engine through the same path as a written literal, so every bit of a witness would have read as constant. Bits now inherit from the value being decomposed.
- `Select` and `Lookup2` returned an input pointer directly, so the result aliased a branch and would read as constant even when the selector is not. Both copy first.

## Tests

Three tests in `std/math/bits/engine_constness_test.go`, all failing on `master`:

```
TestConstnessIsUniformAcrossTheEngine        the flag is engine-wide, not per value
TestCompilerAndEngineTakeDifferentBranches   the branch divergence from #650
TestConstnessPropagates                      the ToBinary over-claiming case
```

Results are reported through pointer fields because `IsSolved` copies the circuit, so a write to a plain `bool` field does not come back.

`SetAllVariablesAsConstants` keeps its documented meaning and is covered.

## Compatibility

Package results are identical to `master` across `./test/...`, `./frontend/...` and `./std/math/...`. No existing test changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the test engine answers ConstantValue, so circuits that branch on constness can take different paths in tests. This is test-only, not proving or constraint generation.
> 
> **Overview**
> Fixes #650: `ConstantValue` in the test engine is no longer a single engine-wide flag. Literals and values derived only from literals report as constant; witnesses and values derived from them do not. `SetAllVariablesAsConstants` still forces everything constant.
> 
> Arithmetic and bit ops now propagate constness via `taint` (absent = non-constant, the safe default). `Mul`’s 0/1 shortcut only runs when the operand is actually constant. `ToBinary` bits inherit from the input instead of looking like Go literals. `Select`/`Lookup2` copy the result so they do not alias a constant branch. Witness assignment stores `*big.Int` so identity (and thus constness) is stable.
> 
> Adds regression tests covering mixed circuits, compiler vs engine branch agreement on `bits.FromBinary`, propagation through `Add`/`ToBinary`, and the `Mul` shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813e6286dc154528d1f6c201dce2986ab9601402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->